### PR TITLE
Fix segmentation faults due to uninitialized pointers and memory

### DIFF
--- a/obliquetree/src/tree.pyx
+++ b/obliquetree/src/tree.pyx
@@ -61,6 +61,7 @@ cdef TreeNode* build_tree_recursive(
     node.x = NULL
     node.missing_go_left = True
     node.n_category = 0
+    node.categories_go_left = NULL
     node.n_samples = n_samples
     node.n_classes = n_classes
 


### PR DESCRIPTION
Hi,
Thank you for developing this `obliquetree` implementation! We were experimenting with your implementation and encountered some segmentation faults. I was able to identify the following bugs due to uninitialized pointers and memory. Please take a look and see if the modifications make sense to you. We hope you can update your Python package so that it is easier for us to install through `pip`.  Thank you!

+ In `tree.pyx`: `node.categories_go_left` is not initialized to `NULL` and leads to unexpected behaviors such as freeing the uninitialized pointer.
+ In `metric.pyx`: the memory of the struct `best_stats` is not initialized and cause unexpected value being stored in to `stats` after `memcpy`.  This happens when `best_stats` is never updated by `memcpy` because `min_impurity < best_impurity` never happens.
+ In `metric.pyx`: I added some if-conditions to avoid freeing `NULL` pointers

Best,
Chiao