### PR TITLE
Fix segmentation faults due to uninitialized members

### DIFF
--- a/obliquetree/src/metric.pyx
+++ b/obliquetree/src/metric.pyx
@@ -901,6 +901,7 @@ cdef double find_best_split_for_categorical_multiclass(
                         for j in range(unique_count):
                             if stats[j].class_weights != NULL:
                                 free(stats[j].class_weights)
+                                stats[j].class_weights = NULL
                         with gil:
                             raise MemoryError()
                     

--- a/obliquetree/src/tree.pyx
+++ b/obliquetree/src/tree.pyx
@@ -64,6 +64,7 @@ cdef TreeNode* build_tree_recursive(
     node.categories_go_left = NULL
     node.n_samples = n_samples
     node.n_classes = n_classes
+    node.value_multiclass = NULL
 
     if n_classes > 2:
         calculate_node_value_multiclass(sample_weight, y, sample_indices, n_samples, n_classes, &node.value_multiclass)


### PR DESCRIPTION
Hi,
We have identified a couple of more segmentation faults due to uninitialized members of `TreeNode`. I think this is related to the issue #2. If the `node.value_multiclass` is not initialized,  `_recurse` called by `export_tree` may wrongly treat a node as results for multiclass classification even when the node is for binary classification. Please take a look and see if the modifications make sense to you. Thanks!

Best,
Chiao